### PR TITLE
Add input-duration.js file to project root

### DIFF
--- a/input-duration.js
+++ b/input-duration.js
@@ -1,1 +1,1 @@
-import './src/input-duration';
+import './src/input-duration.js';

--- a/input-duration.js
+++ b/input-duration.js
@@ -1,0 +1,1 @@
+import './src/input-duration';

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "stylelint": "^13"
   },
   "files": [
+    "input-duration.js",
     "/src",
     "input-duration.serge.json",
     "/lang"

--- a/src/input-duration.js
+++ b/src/input-duration.js
@@ -1,5 +1,5 @@
-import './input-duration-unit';
-import './input-duration-wrapper';
+import './input-duration-unit.js';
+import './input-duration-wrapper.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import LocalizeMixin from './mixins/localize-mixin';


### PR DESCRIPTION
[US127919](https://rally1.rallydev.com/#/431372673576d/iterationstatus?detail=%2Fuserstory%2F603444721280&fdp=true?fdp=true)

This is so it can be imported from the root instead of having to go into the `src` folder.