### PR TITLE
Lit 2 Upgrade: backwards-compatible changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "npm run lint:eslint && npm run lint:lit && npm run lint:style",
     "lint:eslint": "eslint . --ext .js,.html",
-    "lint:lit": "lit-analyzer \"src/**/*.js\" --strict",
+    "lint:lit": "lit-analyzer \"src/**/*.js\" --strict --rules.no-unknown-tag-name off",
     "lint:style": "stylelint \"**/*.{js,html}\"",
     "start": "web-dev-server --app-index demo/index.html --node-resolve --open --watch",
     "test": "npm run lint && npm run test:headless",

--- a/src/input-duration-unit.js
+++ b/src/input-duration-unit.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/colors/colors.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
-import LocalizeMixin from './mixins/localize-mixin';
+import LocalizeMixin from './mixins/localize-mixin.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
 const HORIZONTAL_PADDING = 8;
@@ -223,7 +223,7 @@ class InputDurationUnit extends LocalizeMixin(LitElement) {
 	}
 
 	async focus() {
-		const elem = this.shadowRoot.querySelector('input');
+		const elem = this.shadowRoot?.querySelector('input');
 		if (elem) {
 			elem.focus();
 		} else {
@@ -345,7 +345,7 @@ class InputDurationUnit extends LocalizeMixin(LitElement) {
 	}
 
 	_updateInputLayout() {
-		this._unitContainerWidth = this.shadowRoot.querySelector('.d2l-input-duration-unit-label-container').getBoundingClientRect().width;
+		this._unitContainerWidth = this.shadowRoot?.querySelector('.d2l-input-duration-unit-label-container').getBoundingClientRect().width;
 	}
 }
 customElements.define('d2l-labs-input-duration-unit', InputDurationUnit);

--- a/src/input-duration-wrapper.js
+++ b/src/input-duration-wrapper.js
@@ -5,7 +5,7 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LabelledMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
-import LocalizeMixin from './mixins/localize-mixin';
+import LocalizeMixin from './mixins/localize-mixin.js';
 
 class InputDurationWrapper extends LabelledMixin(LocalizeMixin(LitElement)) {
 	static get properties() {

--- a/src/input-duration.js
+++ b/src/input-duration.js
@@ -2,7 +2,7 @@ import './input-duration-unit.js';
 import './input-duration-wrapper.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
-import LocalizeMixin from './mixins/localize-mixin';
+import LocalizeMixin from './mixins/localize-mixin.js';
 import { repeat } from 'lit-html/directives/repeat.js';
 
 const unitTypes = {
@@ -135,7 +135,7 @@ class InputDuration extends LocalizeMixin(LitElement) {
 		super.updated(changedProperties);
 
 		changedProperties.forEach((oldValue, prop) => {
-			if (prop === 'units') {
+			if (prop === 'units' && this.shadowRoot) {
 				this.unitElements = this.shadowRoot.querySelectorAll('d2l-labs-input-duration-unit');
 			}
 		});


### PR DESCRIPTION
This PR makes backwards-compatible changes to prepare all repos for a Lit 2 upgrade. Since the changes are backwards compatible, it can be merged right away.

Non-breaking change checklist:

- [x] Add missing `.js` extensions for lit-html or lit-element imports
- [x] `await requestUpdate` -> `await elem.updateComplete`
- [x] add non-null checks to shadowRoot accesses (not including test files)
- [x] ensure `undefined` is not passed into unsafeHTML calls
- [x] remove dynamic code from inside  `<template>` tags (Lit files only)
- [x] remove any dependencies on old Lit versions
- [x] audit `ifDefined` usages for null parameters

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.