### PR TITLE
BREAKING CHANGE: Lit 2 Upgrade Breaking Changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.4",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@web/dev-server": "^0.1",
     "@web/test-runner": "^0.13",
     "@web/test-runner-saucelabs": "^0.7",
@@ -41,8 +41,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
-    "lit-element": "^2"
+    "@brightspace-ui/core": "^2",
+    "lit-element": "^3",
+    "lit-html": "^2"
   },
   "version": "1.3.0"
 }


### PR DESCRIPTION
This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**.

Breaking change checklist: 
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used)
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement 
- [x] Remove Dependabot Lit rules
- [x] Bump any dependencies to their Lit 2 versions
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers
- [x] [Backwards-compatible changes merged](https://github.com/BrightspaceUILabs/input-duration/pull/29)

Renamed API's:
- [x] `UpdatingElement` -> `ReactiveElement`
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators)
- [x] `static getStyles()` -> `static finalizeStyles(styles)`
- [x] `_getUpdateComplete()` -> `getUpdateComplete()`
- [x] `NodePart` -> `ChildPart`

Testing checklist: 
- [x] CI/ unit tests pass
- [x] Local testing on demo pages
- [ ] Testing component in the LMS

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.